### PR TITLE
Compability with Python 3 and fix 1065 mysql error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,10 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import sys, os
+import setuptools
+import sys
+import os
+
 src_path = os.path.join(os.path.dirname(__file__), 'src')
 sys.path.insert(0, src_path)
 
@@ -38,6 +41,7 @@ def main():
           url          = 'https://github.com/edbrannin/Robotframework-SQLAlchemy-Library',
           package_dir  = { '' : 'src'},
           packages     = ['SQLAlchemyLibrary'],
+          package_data = {'SQLAlchemyLibrary': ['VERSION']},
           requires     = ['sqlalchemy'],
           install_requires = ['robotframework', 'sqlalchemy'],
           )

--- a/src/SQLAlchemyLibrary/__init__.py
+++ b/src/SQLAlchemyLibrary/__init__.py
@@ -14,9 +14,9 @@
 
 import os
 
-from connection_manager import ConnectionManager
-from query import Query
-from assertion import Assertion
+from SQLAlchemyLibrary.connection_manager import ConnectionManager
+from SQLAlchemyLibrary.query import Query
+from SQLAlchemyLibrary.assertion import Assertion
 
 __version_file_path__ = os.path.join(os.path.dirname(__file__), 'VERSION')
 __version__ = open(__version_file_path__, 'r').read().strip()

--- a/src/SQLAlchemyLibrary/assertion.py
+++ b/src/SQLAlchemyLibrary/assertion.py
@@ -39,8 +39,8 @@ class Assertion(object):
         | Check If Exists In Database | SELECT id FROM person WHERE first_name = 'John' | # FAIL |
         """
         if not self.query(selectStatement):
-            raise AssertionError("Expected to have have at least one row from '%s' "
-                                 "but got 0 rows." % selectStatement)
+            raise AssertionError("Expected to have have at least one row from '{}' "
+                                 "but got 0 rows.".format(selectStatement))
 
     def check_if_not_exists_in_database(self,selectStatement):
         """
@@ -64,8 +64,8 @@ class Assertion(object):
         """
         queryResults = self.query(selectStatement)
         if queryResults:
-            raise AssertionError("Expected to have have no rows from '%s' "
-                                 "but got some rows : %s." % (selectStatement, queryResults))
+            raise AssertionError("Expected to have have no rows from '{}' "
+                                 "but got some rows : {}.".format(selectStatement, queryResults))
 
     def row_count_is_0(self,selectStatement):
         """
@@ -86,8 +86,8 @@ class Assertion(object):
         """
         num_rows = self.row_count(selectStatement)
         if (num_rows > 0):
-            raise AssertionError("Expected zero rows to be returned from '%s' "
-                                 "but got rows back. Number of rows returned was %s" % (selectStatement, num_rows))
+            raise AssertionError("Expected zero rows to be returned from '{}' "
+                                 "but got rows back. Number of rows returned was {}".format(selectStatement, num_rows))
 
     def row_count_is_equal_to_x(self,selectStatement,numRows):
         """
@@ -109,8 +109,8 @@ class Assertion(object):
         """
         num_rows = self.row_count(selectStatement)
         if (num_rows != int(numRows.encode('ascii'))):
-            raise AssertionError("Expected same number of rows to be returned from '%s' "
-                                 "than the returned rows of %s" % (selectStatement, num_rows))
+            raise AssertionError("Expected same number of rows to be returned from '{}' "
+                                 "than the returned rows of {}".format(selectStatement, num_rows))
 
     def row_count_is_greater_than_x(self,selectStatement,numRows):
         """
@@ -132,8 +132,8 @@ class Assertion(object):
         """
         num_rows = self.row_count(selectStatement)
         if (num_rows <= int(numRows.encode('ascii'))):
-            raise AssertionError("Expected more rows to be returned from '%s' "
-                                 "than the returned rows of %s" % (selectStatement, num_rows))
+            raise AssertionError("Expected more rows to be returned from '{}' "
+                                 "than the returned rows of {}".format(selectStatement, num_rows))
 
     def row_count_is_less_than_x(self,selectStatement,numRows):
         """Check if the number of rows returned from `selectStatement` is less
@@ -154,8 +154,8 @@ class Assertion(object):
         """
         num_rows = self.row_count(selectStatement)
         if (num_rows >= int(numRows.encode('ascii'))):
-            raise AssertionError("Expected less rows to be returned from '%s' "
-                                 "than the returned rows of %s" % (selectStatement, num_rows))
+            raise AssertionError("Expected less rows to be returned from '{}' "
+                                 "than the returned rows of {}".format(selectStatement, num_rows))
 
     def table_must_exist(self, table_name, schema_name=None):
         """*DEPRECATED* Use keyword `Table Should Exist` instead."""
@@ -177,12 +177,12 @@ class Assertion(object):
         table = sqlalchemy.schema.Table(table_name, md, schema=schema_name)
         if not table.exists():
             if schema_name is not None:
-                table_name = "%s.%s" % (table_name, schema_name)
+                table_name = "{}.{}".format(table_name, schema_name)
             if message:
-                message = ": %s" % message
+                message = ": {}".format(message)
             else:
-                message = ''
-            raise AssertionError("Table '%s' should exist but does not%s" % (table_name, message))
+                message = ""
+            raise AssertionError("Table '{}' should exist but does not {}".format(table_name, message))
 
     def query_for_single_column(self, selectStatement, *expected_values, **params):
         """
@@ -267,10 +267,10 @@ class Assertion(object):
         """
         values = self.query(selectStatement, **named_args)
         BuiltIn().length_should_be(values, 1,
-                "There should be exactly one row returned by the query %s" % selectStatement)
+                "There should be exactly one row returned by the query {}".format(selectStatement))
         row = values[0]
         BuiltIn().length_should_be(row, 1,
-                "There should be exactly one column in the results of %s" % selectStatement)
+                "There should be exactly one column in the results of {}".format(selectStatement))
         answer = row[0]
         if expected_value is not None:
             BuiltIn().should_be_equal(answer, expected_value, message)

--- a/src/SQLAlchemyLibrary/connection_manager.py
+++ b/src/SQLAlchemyLibrary/connection_manager.py
@@ -12,7 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import ConfigParser
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
 
 from robot.api import logger
 import sqlalchemy

--- a/src/SQLAlchemyLibrary/query.py
+++ b/src/SQLAlchemyLibrary/query.py
@@ -119,7 +119,7 @@ class Query(object):
         will get:
         | Delete All Rows From Table | first_name | # FAIL |
         """
-        selectStatement = ("DELETE FROM %s;" % tableName)
+        selectStatement = ("DELETE FROM %s" % tableName)
         self.execute_sql_string(selectStatement)
 
     def is_comment(self, sql_line):

--- a/src/SQLAlchemyLibrary/query.py
+++ b/src/SQLAlchemyLibrary/query.py
@@ -249,6 +249,6 @@ class Query(object):
 
     def _run_query_list(self, queries, **named_args):
         with self._dbconnection.begin():
-            for query in queries:
+            for query in filter(str.strip, queries):
                 self._dbconnection.execute(query, **named_args)
 

--- a/src/SQLAlchemyLibrary/query.py
+++ b/src/SQLAlchemyLibrary/query.py
@@ -119,7 +119,7 @@ class Query(object):
         will get:
         | Delete All Rows From Table | first_name | # FAIL |
         """
-        selectStatement = ("DELETE FROM %s" % tableName)
+        selectStatement = ("DELETE FROM {}".format(tableName))
         self.execute_sql_string(selectStatement)
 
     def is_comment(self, sql_line):
@@ -237,7 +237,7 @@ class Query(object):
         if len(answer) == 0:
             return answer
         BuiltIn().length_should_be(answer[0], 1,
-                "Expected one column in the rest of %s" % selectStatement)
+                "Expected one column in the rest of {}".format(selectStatement))
         answer = [row[0] for row in answer]
         if len(expected_values) > 0:
             try:


### PR DESCRIPTION
Compability fixes are based on commit `8f89bf2e20c8d641bc8db0479f1099f7afa62a2` in original DatabaseLibrary repo.
1065 mysql error was caused by double semicolon, so running it before fix yields `InternalError: (pymysql.err.InternalError) (1065, 'Query was empty')`.
In my changes I propose to filter empty queries and remove unnecesary semicolon at the end of query `"DELETE FROM {}"`
