### PR TITLE
fix: use sqlparse for better handling of sql statements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def main():
           packages     = ['SQLAlchemyLibrary'],
           package_data = {'SQLAlchemyLibrary': ['VERSION']},
           requires     = ['sqlalchemy', 'sqlparse'],
-          install_requires = ['robotframework', 'sqlalchemy'],
+          install_requires = ['robotframework', 'sqlalchemy', 'sqlparse'],
           )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def main():
           package_dir  = { '' : 'src'},
           packages     = ['SQLAlchemyLibrary'],
           package_data = {'SQLAlchemyLibrary': ['VERSION']},
-          requires     = ['sqlalchemy'],
+          requires     = ['sqlalchemy', 'sqlparse'],
           install_requires = ['robotframework', 'sqlalchemy'],
           )
 

--- a/test/MySQL_DB_Tests.robot
+++ b/test/MySQL_DB_Tests.robot
@@ -110,10 +110,15 @@ Insert Data Into Table foobar
     Log    ${output}
     Should Be Equal As Strings    ${output}    None
 
-Verify Query - Row Count foobar table 1 row
+Insert Data Into Table foobar With Semicolon In String
+    ${output} =    Execute SQL String    INSERT INTO foobar VALUES(2,'aa ; bb');
+    Log    ${output}
+    Should Be Equal As Strings    ${output}    None
+
+Verify Query - Row Count foobar table 2 rows
     ${output} =    Query    SELECT COUNT(*) FROM foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    ((1,),)
+    Should Be Equal As Strings    ${output}    ((2,),)
 
 Verify Delete All Rows From Table - foobar
     Delete All Rows From Table    foobar


### PR DESCRIPTION
To split sql statements we need to use a parser that checks
if a (;) symbol is at the end of the statement. For example
`INSERT INTO some_strings VALUES ('a;b');` got semicolon inside a string.

ignore warnings: for ex. MySQL `CREATE TABLE IF NOT EXISTS` causes one

Do not use sqlparse flag "strip comments" (`/*! Mysql statement */` is not a comment. I think it is a bug in sqlparse lib)
